### PR TITLE
feat: add remove and restore embed context menu actions

### DIFF
--- a/commands/remove-embed.js
+++ b/commands/remove-embed.js
@@ -1,0 +1,34 @@
+const {
+	ContextMenuCommandBuilder,
+	ApplicationCommandType,
+	MessageFlags,
+} = require('discord.js');
+
+const data = new ContextMenuCommandBuilder()
+	.setName('Remove embed')
+	.setType(ApplicationCommandType.Message);
+
+module.exports = {
+	data: data,
+	async execute(interaction) {
+		try {
+			const message = await interaction.channel.messages.fetch(
+				interaction.targetId,
+			);
+
+			await message.suppressEmbeds(true);
+
+			await interaction.reply({
+				content: 'Embeds successfully removed.',
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+		catch (error) {
+			console.error('Error suppressing embeds:', error);
+			await interaction.reply({
+				content: 'Failed to remove embeds. Please ensure I have the "Manage Messages" permission in this channel.',
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+	},
+};

--- a/commands/restore-embed.js
+++ b/commands/restore-embed.js
@@ -1,0 +1,34 @@
+const {
+	ContextMenuCommandBuilder,
+	ApplicationCommandType,
+	MessageFlags,
+} = require('discord.js');
+
+const data = new ContextMenuCommandBuilder()
+	.setName('Restore embed')
+	.setType(ApplicationCommandType.Message);
+
+module.exports = {
+	data: data,
+	async execute(interaction) {
+		try {
+			const message = await interaction.channel.messages.fetch(
+				interaction.targetId,
+			);
+
+			await message.suppressEmbeds(false);
+
+			await interaction.reply({
+				content: 'Embeds successfully restored.',
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+		catch (error) {
+			console.error('Error restoring embeds:', error);
+			await interaction.reply({
+				content: 'Failed to restore embeds. Please ensure I have the "Manage Messages" permission in this channel.',
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+	},
+};


### PR DESCRIPTION
Instead of scanning every single message sent in the server to remove embeds, let's try letting trusted users remove the embeds of other users's messages.
_We'll limit who can use this command later in the server settings_